### PR TITLE
Upgrade packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,10 +5,20 @@
  * Pick color from palette by index
  */
 
-const parse = require('color-parse');
+const parse = require('color-parse').default;
 const hsl = require('color-space/hsl');
-const lerp = require('lerp');
-const clamp = require('clamp');
+
+
+function clamp(value, min, max) {
+  return min < max
+    ? (value < min ? min : value > max ? max : value)
+    : (value < max ? max : value > min ? min : value)
+}
+
+
+function lerp(start, stop, step) {
+    return start*(1-step)+stop*step
+}
 
 module.exports = interpolate;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,70 +1,41 @@
 {
   "name": "color-interpolate",
   "version": "1.0.5",
-  "lockfileVersion": 1,
+  "lockfileVersion": 3,
   "requires": true,
-  "dependencies": {
-    "almost-equal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/almost-equal/-/almost-equal-1.1.0.tgz",
-      "integrity": "sha1-+FHGMROHV5lCdqou++jfowZszN0="
-    },
-    "clamp": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
-      "integrity": "sha1-ZqDmQBGBbjcZaCj9yMjBRzEshjQ="
-    },
-    "color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "color-parse": {
-      "version": "1.3.8",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.3.8.tgz",
-      "integrity": "sha512-1Y79qFv0n1xair3lNMTNeoFvmc3nirMVBij24zbs1f13+7fPpQClMg5b4AuKXLt3szj7BRlHMCXHplkce6XlmA==",
-      "requires": {
-        "color-name": "^1.0.0",
-        "defined": "^1.0.0",
-        "is-plain-obj": "^1.1.0"
+  "packages": {
+    "": {
+      "name": "color-interpolate",
+      "version": "1.0.5",
+      "license": "MIT",
+      "dependencies": {
+        "color-parse": "^2.0.2",
+        "color-space": "^2.3.2"
       }
     },
-    "color-space": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-1.16.0.tgz",
-      "integrity": "sha512-A6WMiFzunQ8KEPFmj02OnnoUnqhmSaHaZ/0LVFcPTdlvm8+3aMJ5x1HRHy3bDHPkovkf4sS0f4wsVvwk71fKkg==",
-      "requires": {
-        "hsluv": "^0.0.3",
-        "mumath": "^3.3.4"
+    "node_modules/color-name": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-2.0.0.tgz",
+      "integrity": "sha512-SbtvAMWvASO5TE2QP07jHBMXKafgdZz8Vrsrn96fiL+O92/FN/PLARzUW5sKt013fjAprK2d2iCn2hk2Xb5oow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM="
-    },
-    "hsluv": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/hsluv/-/hsluv-0.0.3.tgz",
-      "integrity": "sha1-gpEH2vtKn4tSoYCe0C4JHq3mdUw="
-    },
-    "is-plain-obj": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-      "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
-    },
-    "lerp": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/lerp/-/lerp-1.0.3.tgz",
-      "integrity": "sha1-oYyJaPkXiW3hXM/MKNVaa3Med24="
-    },
-    "mumath": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/mumath/-/mumath-3.3.4.tgz",
-      "integrity": "sha1-SNSg8P2MrU57Mglu6JsWGmPTC78=",
-      "requires": {
-        "almost-equal": "^1.1.0"
+    "node_modules/color-parse": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.2.tgz",
+      "integrity": "sha512-eCtOz5w5ttWIUcaKLiktF+DxZO1R9KLNY/xhbV6CkhM7sR3GhVghmt6X6yOnzeaM24po+Z9/S1apbXMwA3Iepw==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^2.0.0"
       }
+    },
+    "node_modules/color-space": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
+      "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
+      "license": "Unlicense"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "color-interpolate",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Pick color from a given color palette by index",
   "main": "index.js",
   "types": "index.d.ts",
@@ -17,7 +17,6 @@
     "lerp",
     "interpolate-arrays",
     "interpolation",
-    "lerp",
     "smootstep",
     "palette",
     "colormap",
@@ -30,9 +29,7 @@
   },
   "homepage": "https://github.com/colorjs/color-interpolate#readme",
   "dependencies": {
-    "clamp": "^1.0.1",
-    "color-parse": "^1.2.0",
-    "color-space": "^1.14.3",
-    "lerp": "^1.0.3"
+    "color-parse": "^2.0.2",
+    "color-space": "^2.3.2"
   }
 }


### PR DESCRIPTION
Remove lerp/clamp packages as they open for more supply chain attacks, where the entire package is 2-3 loc.

Upgrade color-parse to 2.0.2, fix import
Upgrade color-space, required no extra changes.

Bump version